### PR TITLE
Add content to testing page

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -57,5 +57,14 @@ module.exports = {
         }
       ]
     }
-  }
+  },
+  plugins: [
+    [
+      "vuepress-plugin-container",
+      {
+        type: "info",
+        defaultTitle: ""
+      }
+    ]
+  ]
 }

--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -1,0 +1,8 @@
+.custom-block.info {
+  background-color: #f3f5f7;
+  border-left-color: #dfdfdf;
+  border-left-style: solid;
+  border-left-width: 0.5rem;
+  margin: 1rem 0;
+  padding: 0.1rem 1.5rem;
+}

--- a/docs/code/testing/README.md
+++ b/docs/code/testing/README.md
@@ -1,4 +1,27 @@
 # Testing
 
-TODO: Visual
-TODO: Functional / Unit
+Our approach to testing is a _subjective_ one:
+
+::: info
+We test to the extent that it instills a reasonable level of confidence in the code we ship to production.
+:::
+
+While this leaves room for the lead on any project to implement testing how they feel it best serves the project, we generally follow these guidelines:
+
+## Code Coverage
+
+_Code coverage_ is not a reliable means for measuring confidence in a project's code. Striving for a particular level of coverage is an expensive effort that doesn't proportionally yield the protection one would expect. Instead we aim to make reasonable decisions about what to test, relative to the time spent writing tests.
+
+## Visual Testing
+
+To date, our visual testing is done manually by both the developer and the team member assigned to QA the work.
+
+On component-based work, we've used an array of different products, including [Storybook](https://storybook.js.org/) and [Docz](https://www.docz.site/). We've also spun up our own version.
+
+We are working to consolidate our efforts and land on a process we believe will serve us best _most_ of the time. But for the time being, it is best to reference the individual project and follow what it is using. For new projects, follow what the appropriate starter kit's recommendation.
+
+## Unit Testing
+
+Being that we work primarily with the Jamstack these days, unit testing consists of the majority of tests we write. Typically you'll find that specs are testing either knowledge or rendering. The rendering tests are put in place as a means to notify us when a component has changed.
+
+The framework used may vary depending on the project, but we work to stay with the communities' recommendations. That means for most React-based projects we're using [Jest](https://jestjs.io/) as the testing framework.


### PR DESCRIPTION
Also adds support for info containers. I thought this would be a nice option to highlight text without needing a title like the tip container requires.

Preview: https://deploy-preview-31--dev-playbook.netlify.app/code/testing/#code-coverage