### PR TITLE
Starter Kits

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -45,7 +45,7 @@ module.exports = {
           children: [
             ["/code/", "Overview"],
             "/code/syntax-styleguides/",
-            "/code/working-with-gatsby/",
+            "/code/starter-kits/",
             "/code/testing/",
             "/code/data-architecture/",
             "/code/component-architecture/"

--- a/docs/code/starter-kits/README.md
+++ b/docs/code/starter-kits/README.md
@@ -1,0 +1,33 @@
+# Starter Kits
+
+Ample's starter kits have served as a means of providing some basis of standardization (read: _consistency_) across our Jamstack projects.
+
+[Settling down with the Jamstack](https://www.helloample.com/blog/settling-down-in-a-jamstack-world) is a difficult accomplishment, as it's a moving target. We have to be consistently innovating _and_ settling in. The starter kits have helped us form a foundation from which we can build a balanced approach to building Jamstack sites and applications smoothly (without taking the fun out of it).
+
+We support two starter kits today:
+
+- GatsbyJS: [ample/gatsby-starter-ample](https://github.com/ample/gatsby-starter-ample)
+- Next.js: [ample/next-starter-ample](https://github.com/ample/next-starter-ample)
+
+Both are in use and supported, although the Gatsby version tends to be used more heavily and stays up to date more quickly.
+
+## Why a Monorepo?
+
+At this time, these projects are built as monorepos. That means that their code and all supporting code lives in a single repository. This was done to make it easier to manage issues and code.
+
+But, more importantly, it reduces dependencies across multiple projects. That means that once a starter kit is copied to begin a project, all of its _Ample-developed_ dependencies (i.e. _plugins_) are locked in place for that project. Updating those plugins will henceforth only affect that project.
+
+## Distributed Documentation
+
+These starter kits follow a practice we call _distributed documentation_. What we mean by that is that every project bring its own relevant documentation with it. This prevents us from needing to worry about versioning the starter kit. It's always the most up to date it can be. But it also means when going back to a previous project, all relevant documentation is self-contained (or at least referenced) from within that project.
+
+## Handling Updates
+
+Updates are a team effort. Opportunities are most frequently identified when working with a single instance of the starter kit (i.e. within an Ample project). It is every dev's responsibility to keep an eye out for those opportunities and act when one appears, like so:
+
+- If the change to the starter would be quick (say about 15-30 minutes), then it is our expectation that you will take the time away from your project to contribute to the starter by opening a PR with the change.
+- If the change is a question, needs research, or is a bigger task, create a GitHub issue. The repo maintainer(s) will review and respond as available.
+
+## Support
+
+At this time, Sean supports the Gatsby starter and Jeff supports the Next.js starter. If you have a specific question, GitHub issues are the preferred way to communicate. But if it requires faster turnaround, feel free to contact them directly.

--- a/docs/code/working-with-gatsby/README.md
+++ b/docs/code/working-with-gatsby/README.md
@@ -1,5 +1,11 @@
 # Working with Gatsby
 
+:::warning
+This page is currently out of date and will soon be removed. Our approach to projects has been spread out among the playbook, along with other locations.
+
+Please visit [the Starter Kits guide](/code/starter-kits) as a starting point for working with Gatsby.
+:::
+
 Our framework of choice is [Gatsby](https://www.gatsbyjs.org/). Gatsby is an open source framework based on React that helps developers build blazing fast websites and apps.
 
 If you're new to Gatsby, start by getting familiar with the framework. They have some great tutorials [on their site](https://www.gatsbyjs.org/tutorial/). But it's a popular framework — there's an abundance of intro tutorials out there.
@@ -222,7 +228,7 @@ Our approach is fairly loose when writing stylesheets. We aim to follow a few ba
 - Use `.component_name` as the wrapping selector for the component.
 - In components nest all styles under `.component_name`
 - In components use underscores to separate words
-    - Allows for easier usage with props via `styles['some_style']` instead of requiring you to convert to camel case `styles['someStyle']` when using dashes.
+  - Allows for easier usage with props via `styles['some_style']` instead of requiring you to convert to camel case `styles['someStyle']` when using dashes.
 - Keep your SCSS as flat as possible.
 - When using CSS modules use generic element selectors over class names as much as possible.
 - Make use of the [classnames utility](https://www.npmjs.com/package/classnames) for concatenating class names together.


### PR DESCRIPTION
Adds a _Starter Kits_ page. I kept this open-ended as the way to approach the kits, noting that the documentation on usage and all that is intended to be distributed.

It also deprecates (but saves) the _Working with Gatsby_ page. More on this below.

Note that ample/gatsby-starter-ample#106 contains a path forward for the Gatsby starter's documentation. We're slowly adding it. As I work my way through #14 and #15, I'll also spend some time enhancing the Gatsby starter's README(s). Until that time, I want to keep the Gatsby doc around here. When #14, #15, and the starter docs are all up to date, I'll kill that Gatsby file.

---

[Preview](https://deploy-preview-33--dev-playbook.netlify.app/code/starter-kits/)

---

Fixes #30 